### PR TITLE
fixed calendar range selection and added sample to demo script

### DIFF
--- a/calendar_demo/calendar_demo/calendar_demo.py
+++ b/calendar_demo/calendar_demo/calendar_demo.py
@@ -7,11 +7,17 @@ import reflex as rx
 
 class Foo(rx.State):
     selected_date: str = ""
+    start_date: str = ""
+    end_date: str = ""
     logs: list[str] = []
 
     def change_handler(self, var):
         self.selected_date = var
         return self.add_log(f"Changed selected date: {var}")
+
+    def change_range_handler(self, var):
+        self.start_date, self.end_date = var
+        return self.add_log(f"Changed selected date range: {self.start_date} {self.end_date}")
 
     def active_start_date_change_handler(self, var):
         if "drill" in var["action"]:
@@ -80,6 +86,27 @@ def demo():
             locale="fr-FR",
             on_active_start_date_change=Foo.active_start_date_change_handler,
             on_change=Foo.change_handler,
+            on_click_day=Foo.click_day_handler,
+            on_click_month=Foo.click_month_handler,
+            on_click_decade=Foo.click_decade_handler,
+            on_click_year=Foo.click_year_handler,
+            on_click_week_number=Foo.click_week_number_handler,
+            on_drill_down=Foo.drill_down_handler,
+            on_drill_up=Foo.drill_up_handler,
+            # on_view_change=Foo.view_change_handler,
+        ),
+        rx.spacer(),
+        rx.hstack(
+            rx.moment(Foo.start_date, format="MMMM D, YYYY", size="4"),
+            rx.moment(Foo.end_date, format="MMMM D, YYYY", size="4"),
+        ),
+        calendar(
+            go_to_range_start_on_select=True,
+            locale="fr-FR",
+            on_active_start_date_change=Foo.active_start_date_change_handler,
+            select_range=True,
+            return_value="range",
+            on_change=Foo.change_range_handler,
             on_click_day=Foo.click_day_handler,
             on_click_month=Foo.click_month_handler,
             on_click_decade=Foo.click_decade_handler,

--- a/calendar_demo/calendar_demo/calendar_demo.py
+++ b/calendar_demo/calendar_demo/calendar_demo.py
@@ -17,7 +17,7 @@ class Foo(rx.State):
 
     def change_range_handler(self, var):
         self.start_date, self.end_date = var
-        return self.add_log(f"Changed selected date range: {self.start_date} {self.end_date}")
+        return self.add_log(f"Changed selected date range: {self.start_date} - {self.end_date}")
 
     def active_start_date_change_handler(self, var):
         if "drill" in var["action"]:

--- a/custom_components/reflex_calendar/calendar.py
+++ b/custom_components/reflex_calendar/calendar.py
@@ -22,10 +22,10 @@ def _on_active_start_date_change_spec(e0):
 def _on_change_spec(date) -> list[rx.Var]:
     return [
         rx.cond(
-            rx.Var(f"{date}") == "None",
+            rx.Var(f"Array.isArray({date})"),
+            rx.Var(f"{date}.map(d => d.toDateString())"),
             rx.Var(f"{date}.toDateString()"),
-            rx.Var(f"{date}")
-        )
+        ),
     ]
 
 

--- a/custom_components/reflex_calendar/calendar.py
+++ b/custom_components/reflex_calendar/calendar.py
@@ -20,7 +20,13 @@ def _on_active_start_date_change_spec(e0):
 
 
 def _on_change_spec(date) -> list[rx.Var]:
-    return [rx.Var(f"{date}.toDateString()")]
+    return [
+        rx.cond(
+            rx.Var(f"{date}") == "None",
+            rx.Var(f"{date}.toDateString()"),
+            rx.Var(f"{date}")
+        )
+    ]
 
 
 def _on_click_day_spec(date) -> list[rx.Var]:


### PR DESCRIPTION
Summary: Calendar range selection was hitting an error with message: TypeError: _date.toDateString is not a function. Issue has been reported: https://github.com/Lendemor/reflex-calendar/issues/1 
This error occurs due to _on_change_spec() method being called with value "None" when the select_range is set to True and return_value is set to range.
